### PR TITLE
fix(valkey): update timeout and overload to ignore shell stale env

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 4. change the data type of boards and gamehistory to array of bool only and the array too kept 1 D only - [x]
 5. make the signin endpoint - [x]
 6. handle profile pic in player table - [x]
-7. 15 minutes of playable time instead of total elapsed time - [ ]
+7. 15 minutes of playable time instead of total elapsed time - [ ] (calculate time spent in between request received and response using defer )
 8. Find race conditions and manage concurrency - [ ]
 9. Find memory leaks - [ ]
 10. middlewares and their chaining and their database tables - [ ]

--- a/config/env.go
+++ b/config/env.go
@@ -25,8 +25,9 @@ var (
 func InitEnv() error {
 	var initErr error
 	initOnce.Do(func() {
-		// Load .env for local/dev
-		_ = godotenv.Load()
+		// Load .env for local/dev and let it override stale shell exports.
+		// This keeps checked-in local config authoritative when both exist.
+		_ = godotenv.Overload()
 
 		// Detect environment mode
 		if os.Getenv("RENDER_GIT_PULL_REQUEST") != "" {

--- a/main.go
+++ b/main.go
@@ -58,14 +58,14 @@ func main() {
 	poolConfig.MaxConnIdleTime = 5 * time.Minute
 	poolConfig.HealthCheckPeriod = 30 * time.Second
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	dbCtx, dbCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer dbCancel()
+	pool, err := pgxpool.NewWithConfig(dbCtx, poolConfig)
 	if err != nil {
 		log.Fatal("failed to create pgx pool:", err)
 	}
 
-	if err := pool.Ping(ctx); err != nil {
+	if err := pool.Ping(dbCtx); err != nil {
 		log.Fatal("failed to connect to database:", err)
 	}
 
@@ -76,7 +76,9 @@ func main() {
 		log.Fatal("failed to parse VALKEY_URL:", err)
 	}
 	valkeyClient := redis.NewClient(valkeyOpts)
-	if err := valkeyClient.Ping(ctx).Err(); err != nil {
+	valkeyCtx, valkeyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer valkeyCancel()
+	if err := valkeyClient.Ping(valkeyCtx).Err(); err != nil {
 		log.Fatal("failed to connect to Valkey:", err)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup checks by giving database and cache connections their own dedicated timeouts.
  * Environment variables from local `.env` files can now override existing exported values, making local configuration behave as expected.

* **Documentation**
  * Updated the task list with the planned approach for measuring playable time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->