### PR TITLE
fix(supabase-pooler): QueryExecModeExec avoids named prepared statements

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	firebase "firebase.google.com/go/v4"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
@@ -51,6 +52,9 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to parse DATABASE_URL:", err)
 	}
+	// Supabase's pooler can reuse backend connections across sessions, so avoid
+	// named prepared statements. QueryExecModeExec keeps pgx off the statement cache.
+	poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
 	// Pool tuning (adjust as needed)
 	poolConfig.MaxConns = 10
 	poolConfig.MinConns = 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query handling to make pooled connections more reliable.
  * Reduced the chance of intermittent errors when the app reuses database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->